### PR TITLE
Update loader.js

### DIFF
--- a/lib/cmds/loader.js
+++ b/lib/cmds/loader.js
@@ -130,15 +130,16 @@ mods = {
     scan: function() {
         var self = this,
             dirs = fs.readdirSync(this.start),
-            metaFiles = [];
+            metaFiles = [],
+            base = self.base || '';
 
         dirs.forEach(function(d) {
             if (self.strict) {
-                if (!util.exists(path.join(self.base, d, 'build.json'))) {
+                if (!util.exists(path.join(base, d, 'build.json'))) {
                     return; //No build.json file, exclude this automatically
                 }
             }
-            var p = path.join(self.base, d, 'meta'),
+            var p = path.join(base, d, 'meta'),
                 files;
             if (util.exists(p)) {
                 files = fs.readdirSync(p);


### PR DESCRIPTION
Node v0.10 no longer silently ignores non-string values, but throws an exception.
