### PR TITLE
Run yogi loader outside of the src directory

### DIFF
--- a/lib/cmds/loader.js
+++ b/lib/cmds/loader.js
@@ -43,7 +43,16 @@ mods = {
 
         this.expand = this.options.parsed.expand;
 
-        this.start = this.options.parsed.start || process.cwd();
+        this.start = self.options.parsed.start;
+        if (!this.start) {
+            util.find(process.cwd(), '.yogi.json', function(val, dir) {
+                self.start = path.join(path.dirname(dir), 'src');
+            });
+        }
+        if (!this.start || !fs.existsSync(this.start)) {
+            log.info("Cannot find .yogi.json. Defaulting base directory to current working directory");
+            this.start = process.cwd();
+        }
 
         process.chdir(this.start);
 
@@ -130,9 +139,9 @@ mods = {
     },
     scan: function() {
         var self = this,
-            dirs = fs.readdirSync(this.start),
-            metaFiles = [],
-            base = self.base || '';
+            base = this.start,
+            dirs = fs.readdirSync(base),
+            metaFiles = [];
 
         dirs.forEach(function(d) {
             if (self.strict) {


### PR DESCRIPTION
### Motivation

Currently, if the `yogi loader` command is called, the loader will generate a list of all the modules in a yui3.json. But the loader is limited to being run inside the src folder. Just as Shifter is able to normalize the execution directory, yogi should be able to run within any module directory.
### Assumptions

Just like how Shifter uses a .shifter.json file to configure a build, a .yogi.json file would be needed in the future to configure module deployment.
### Usage

By defining the start option, we override the automatic directory normalization.
##### Examples of Automatic Path Nomalization

> ~/ yogi loader

or:

> ~/src yogi loader
##### Examples of Manual Path Configuration

> / yogi loader --start [path to repo]

or:

> ~/src yogi loader --start ../
