### PR TITLE
Added 'yogi perf'

### DIFF
--- a/lib/args.js
+++ b/lib/args.js
@@ -61,7 +61,9 @@ var nopt = require('nopt'),
         outfile: path,
         loglevel: [ 'silent', 'info', 'debug', 'warn' ],
         lint: [ 'defaults', 'strict', 'preferred' ],
-        filter: [ 'raw', 'min', 'debug', 'coverage' ]
+        filter: [ 'raw', 'min', 'debug', 'coverage' ],
+        ref: [String, Array],
+        working: [Boolean]
     },
     shorts = {
         'y' : ['--yes'],
@@ -108,7 +110,7 @@ exports.parse = function(args) {
 
     //default to false
     parsed.yes = (parsed.yes === undefined || parsed.yes === false) ? false : true;
-    
+
     //defaults to true
     parsed.istanbul = (parsed.istanbul === undefined || parsed.istanbul) ? true : false;
 

--- a/lib/args.js
+++ b/lib/args.js
@@ -63,7 +63,7 @@ var nopt = require('nopt'),
         lint: [ 'defaults', 'strict', 'preferred' ],
         filter: [ 'raw', 'min', 'debug', 'coverage' ],
         ref: [String, Array],
-        working: [Boolean]
+        working: Boolean
     },
     shorts = {
         'y' : ['--yes'],

--- a/lib/cmds/perf.js
+++ b/lib/cmds/perf.js
@@ -32,12 +32,12 @@ var util = require('../util'),
                 component,
                 testpaths;
 
-                options = this.options = opts.parsed;
-                yuiRoot = this.yuiRoot = path.join(git.findRoot(), '..');
-                module = this.module = util.getPackage(true);
-                mod = util.findModule(true);
-                component = (options.component || (mod && mod.name));
-                testpaths = glob.sync(path.join(yuiRoot, '/src/' + (component ? component : '*') + '/tests/performance/*.js'));
+            options = this.options = opts.parsed;
+            yuiRoot = this.yuiRoot = path.join(git.findRoot(), '..');
+            module = this.module = util.getPackage(true);
+            mod = util.findModule(true);
+            component = (options.component || (mod && mod.name));
+            testpaths = glob.sync(path.join(yuiRoot, '/src/' + (component ? component : '*') + '/tests/performance/*.js'));
 
             this.executeTests(testpaths);
         },

--- a/lib/cmds/perf.js
+++ b/lib/cmds/perf.js
@@ -1,0 +1,87 @@
+/*jshint maxlen: 300 */
+
+/*
+Copyright (c) 2012, Yahoo! Inc. All rights reserved.
+Code licensed under the BSD License:
+http://yuilibrary.com/license/
+*/
+var util = require('../util'),
+    log = require('../log'),
+    git = require('../git'),
+    spawn = require('win-spawn'),
+    path = require('path'),
+    async = require('async'),
+    glob = require('glob'),
+    mods = {
+        help: function help () {
+            return [
+                'perf',
+                'Executes performance tests'
+            ];
+        },
+        init: function init (opts) {
+            var options,
+                yuiRoot,
+                module,
+                mod,
+                component,
+                testpaths;
+
+                options = this.options = opts.parsed;
+                yuiRoot = this.yuiRoot = path.join(git.findRoot(), '..');
+                module = this.module = util.getPackage(true);
+                mod = util.findModule(true);
+                component = (options.component || (mod && mod.name));
+                testpaths = glob.sync(path.join(yuiRoot, '/src/' + (component ? component : '*') + '/tests/performance/*.js'));
+
+            this.executeTests(testpaths);
+        },
+        executeTests: function executeTests (testpaths) {
+            var options = this.options,
+                yuiRoot = this.yuiRoot,
+                loglevel = (options.loglevel || 'info'),
+                tmp = (options.tmp || false),
+                timeout = (options.timeout || 300),
+                outdir = (options.outdir || false),
+                refs = (options.ref || []),
+                wip = (options.working === undefined ? true : options.working),
+                cmd = path.resolve(__dirname + '/../../node_modules/.bin/yb'),
+                args = [],
+                rawpath;
+
+            args = [
+                '--repo=' + yuiRoot,
+                '--loglevel=' + loglevel,
+                '--working=' + wip,
+                '--timeout=' + timeout,
+                '--phantom=true'
+            ];
+
+            if (tmp) {
+                args.push('--tmp=' + tmp);
+            }
+
+            refs.forEach(function(ref) {
+                args.push('--ref=' + ref);
+            });
+
+            log.info('Found ' + testpaths.length + ' test file' + (testpaths.length > 1 ? 's' : ''));
+            log.debug('Paths: \n' + testpaths.join('\n'));
+
+            async.eachSeries(testpaths, function (testpath, next) {
+                var actualArgs = args.concat('--source=' + testpath);
+
+                if (outdir) {
+                    rawpath = path.resolve(process.cwd(), outdir, path.basename(testpath).replace(/.js$/, '.json'));
+                    actualArgs.push('--raw=' + rawpath);
+                }
+
+                log.info('Executing: ' + testpath);
+                log.debug('Args: ' + actualArgs.join(' '));
+
+                spawn(cmd, actualArgs, {stdio: 'inherit'}).on('close', next);
+            });
+        }
+    };
+
+util.mix(exports, mods);

--- a/lib/cmds/perf.js
+++ b/lib/cmds/perf.js
@@ -16,7 +16,12 @@ var util = require('../util'),
         help: function help () {
             return [
                 'perf',
-                'Executes performance tests'
+                'Executes performance tests',
+                '--loglevel <string> "info" or "debug". Default: info',
+                '--ref <string> Which YUI ref you\'d like to execute the test against. Specify as many as you\'d like (each with its own --ref).',
+                '--timeout <number> How long to wait (in seconds) before aborting this process. Default: 300',
+                '--tmp <path> A path where temporary files can be stored. Default: OS assigned',
+                '--working <boolean> Whether or not to include your working tree as a test ref. Default: true'
             ];
         },
         init: function init (opts) {

--- a/lib/cmds/perf.js
+++ b/lib/cmds/perf.js
@@ -59,7 +59,8 @@ var util = require('../util'),
                 '--loglevel=' + loglevel,
                 '--working=' + wip,
                 '--timeout=' + timeout,
-                '--phantom=true'
+                '--phantom=true',
+                '--autoexecute=true'
             ];
 
             if (tmp) {

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
         "complete": "~0.4.3",
         "promises-aplus-tests": "~1.3.1",
         "async": "~0.2.6",
-        "promises-aplus-tests": "~1.3.1",
         "glob" : "~3.2.1"
     },
     "scripts": {

--- a/package.json
+++ b/package.json
@@ -37,7 +37,10 @@
         "which": "~1.0.5",
         "ansispan": "~0.0.4",
         "complete": "~0.4.3",
-        "promises-aplus-tests": "~1.3.1"
+        "promises-aplus-tests": "~1.3.1",
+        "async": "~0.2.6",
+        "promises-aplus-tests": "~1.3.1",
+        "glob" : "~3.2.1"
     },
     "scripts": {
         "pretest": "jshint --config ./node_modules/yui-lint/jshint.json ./lib/*.js ./lib/*/*.js",


### PR DESCRIPTION
This plugin introduces performance testing to Yogi.

Example commands:

```
# simple, will just tell you the results of perf testing against your working tree
$ yogi perf

# the kitchen sink
$ yogi perf --ref v3.10.0 --ref v3.11.0 --working false --loglevel debug --timeout 500 --tmp /some/tmp/dir
```

`perf` obeys the Yogi pattern of executing all tests in all components if executed from the root of the repo, or just against your local tests if in a component directory.

There is an additional commit to `package.json` which will be added to this PR at some point that will introduce a new module dependency for the actual tool that does the perf testing, but that will need to be released first.

Passes `npm test`.
