### PR TITLE
Making create.js more extensible

### DIFF
--- a/lib/create.js
+++ b/lib/create.js
@@ -164,3 +164,9 @@ var init = function(options, callback) {
         });
     });
 };
+
+module.exports = {
+    init: init,
+    createJSON: createJSON,
+    createDirs: createDirs
+}

--- a/lib/create.js
+++ b/lib/create.js
@@ -173,6 +173,4 @@ replaceTitle : function(options, items, callback) {
     });
   }
 };
-
-
 util.mix(exports, mods);

--- a/lib/create.js
+++ b/lib/create.js
@@ -21,7 +21,7 @@ var _defaultDirs = [
 mods = {
 
   /**
-  Create a JSON
+  Creates the JSON assets for the new module
   @method createJSON
   @param {Object} options {options.name, options.location, options.defaultDirs}
   **/
@@ -175,4 +175,6 @@ replaceTitle : function(options, items, callback) {
 };
 
 util.mix(exports, mods);
+
+
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -164,9 +164,3 @@ var init = function(options, callback) {
         });
     });
 };
-
-module.exports = {
-    init: init,
-    createJSON: createJSON,
-    createDirs: createDirs
-}

--- a/lib/create.js
+++ b/lib/create.js
@@ -173,4 +173,6 @@ replaceTitle : function(options, items, callback) {
     });
   }
 };
+
 util.mix(exports, mods);
+

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,11 +1,12 @@
 var log = require('./log'),
-    cpr = require('cpr').cpr,
-    mkdirp = require('mkdirp'),
-    config = require('./config'),
-    path = require('path'),
-    timethat = require('timethat'),
-    fs = require('fs'),
-    util = require('./util');
+  cpr = require('cpr').cpr,
+  mkdirp = require('mkdirp'),
+  config = require('./config'),
+  path = require('path'),
+  timethat = require('timethat'),
+  fs = require('fs'),
+  util = require('./util'),
+  mods;
 
 
 var _defaultDirs = [
@@ -15,55 +16,63 @@ var _defaultDirs = [
     './meta',
     './css',
     './assets'
-];
+  ];
 
-var createJSON = function(options, callback) {
+mods = {
+
+  /**
+  Create a JSON
+  @method createJSON
+  @param {Object} options {options.name, options.location, options.defaultDirs}
+  **/
+  createJSON : function (options, callback) {
 
     var name = options.name,
-        build = {
-            name: name,
-            builds: {}
-        },
-        meta = {},
-        codeFile = path.join(options.location, 'js', name + '.js'),
-        skinBase = path.join(options.location, 'assets', name, 'skins', 'sam'),
-        file = path.join(options.location, 'build.json'),
-        readme = path.join(options.location, 'README.md'),
-        history = path.join(options.location, 'HISTORY.md'),
-        metaFile = path.join(options.location, 'meta', name + '.json');
+      build = {
+        name: name,
+        builds: {}
+      },
+      meta = {},
+      defaultDirs = options.defaultDirs || _defaultDirs,
+      codeFile = path.join(options.location, 'js', name + '.js'),
+      skinBase = path.join(options.location, 'assets', name, 'skins', 'sam'),
+      file = path.join(options.location, 'build.json'),
+      readme = path.join(options.location, 'README.md'),
+      history = path.join(options.location, 'HISTORY.md'),
+      metaFile = path.join(options.location, 'meta', name + '.json');
 
     build.builds[name] = {
     };
+
     meta[name] = {
     };
 
     switch (options.type) {
-        case 'js':
-            build.builds[name].jsfiles = [
-                'js/' + name + '.js'
-            ];
-            meta[name].requires = [ 'yui-base' ];
-            break;
-        case 'css':
-            codeFile = path.join(options.location, 'css', name + '.css'),
-            build.builds[name].cssfiles = [
-                'css/' + name + '.css'
-            ];
-            meta[name].type = 'css';
-            break;
-        case 'widget':
-            build.builds[name].jsfiles = [
-                'js/' + name + '.js'
-            ];
-            meta[name].requires = [ 'widget' ];
-            meta[name].skinnable = true;
 
-            mkdirp.sync(skinBase);
-            log.info('creating skin templates');
-            fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-            fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-            break;
-
+    case 'js':
+      build.builds[name].jsfiles = [
+        'js/' + name + '.js'
+      ];
+      meta[name].requires = [ 'yui-base' ];
+      break;
+    case 'css':
+      codeFile = path.join(options.location, 'css', name + '.css');
+      build.builds[name].cssfiles = [
+        'css/' + name + '.css'
+      ];
+      meta[name].type = 'css';
+      break;
+    case 'widget':
+      build.builds[name].jsfiles = [
+        'js/' + name + '.js'
+      ];
+      meta[name].requires = [ 'widget' ];
+      meta[name].skinnable = true;
+      mkdirp.sync(skinBase);
+      log.info('creating skin templates');
+      fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+      fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+      break;
     }
 
     log.debug('creating README file: ' + readme);
@@ -72,7 +81,6 @@ var createJSON = function(options, callback) {
     log.debug('creating HISTORY file: ' + history);
     fs.writeFileSync(history, name + '\n========\n', 'utf8');
 
-    
     log.debug('creating code file: ' + codeFile);
     fs.writeFileSync(codeFile, '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
 
@@ -82,86 +90,90 @@ var createJSON = function(options, callback) {
     log.debug('creating meta/' + name + '.json file: ' + metaFile);
     fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
     callback();
-};
+  },
 
-
-var replaceTitle = function(options, items, callback) {
+  replaceTitle : function (options, items, callback) {
     var tags = '[ "gallery" ]',
-        title = options.name;
-        author = config.get('username');
+      title = options.name,
+      author = config.get('username');
 
-    items.forEach(function(file) {
-        var stat = fs.statSync(file), str;
-        if (!stat.isDirectory()) {
-            log.debug('updating title in ' + file);
-            str = fs.readFileSync(file, 'utf8');
-            str = str.replace(/\{\{title\}\}/gi, title);
-            str = str.replace(/\{\{name\}\}/gi, title);
-            str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
-            str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
-            str = str.replace(/\{\{tags\}\}/gi, tags);
-            str = str.replace(/\{\{author\}\}/gi, author);
-            str = str.replace(/\{\{code\}\}/gi, '//Module example code');
-            fs.writeFileSync(file, str, 'utf8');
-        }
+    items.forEach(function (file) {
+
+      var stat = fs.statSync(file), str;
+      if (!stat.isDirectory()) {
+        log.debug('updating title in ' + file);
+        str = fs.readFileSync(file, 'utf8');
+        str = str.replace(/\{\{title\}\}/gi, title);
+        str = str.replace(/\{\{name\}\}/gi, title);
+        str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
+        str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
+        str = str.replace(/\{\{tags\}\}/gi, tags);
+        str = str.replace(/\{\{author\}\}/gi, author);
+        str = str.replace(/\{\{code\}\}/gi, '//Module example code');
+        fs.writeFileSync(file, str, 'utf8');
+      }
     });
-    callback();
-};
 
-var createDirs = function(options, callback) {
+    callback();
+  },
+  createDirs : function (options, callback) {
 
     log.info('creating default directory structure');
     var stack = new util.Stack(),
-        copied = [];
+      copied = [],
+      defaultDirs = options.defaultDirs || _defaultDirs;
 
-    _defaultDirs.forEach(function(dir) {
-        var d = path.join(__dirname, '../defaults/', dir),
-            toDir = path.join(options.location, dir);
+    defaultDirs.forEach(function (dir) {
+      var d = path.join(__dirname, '../defaults/', dir),
+        toDir = path.join(options.location, dir);
 
-        if (util.exists(toDir)) {
-            log.info('did not create default directory, it exists: ' + toDir);
-            return;
-        }
-        if (util.exists(d)) {
-            log.debug('copying dir from ' + d);
-            log.debug('to ' + toDir);
-            mkdirp(toDir, stack.add(function() {
-                cpr(d, toDir, stack.add(function(err, status) {
-                    copied = [].concat(copied, status);
-                }));
-            }));
-        } else {
-            log.debug('making ' + toDir);
-            mkdirp(toDir, stack.add(function() {
-            }));
-        }
+      if (util.exists(toDir)) {
+        log.info('did not create default directory, it exists: ' + toDir);
+        return;
+      }
+      if (util.exists(d)) {
+        log.debug('copying dir from ' + d);
+        log.debug('to ' + toDir);
+        mkdirp(toDir, stack.add(function () {
+          cpr(d, toDir, stack.add(function (err, status) {
+            copied = [].concat(copied, status);
+          }));
+        }));
+      } else {
+        log.debug('making ' + toDir);
+        mkdirp(toDir, stack.add(function () {
+        }));
+      }
     });
-    stack.done(function() {
-        log.info('directories created, processing files');
-        replaceTitle(options, copied, function() {
-            createJSON(options, function() {
-                callback();
-            });
+    stack.done(function () {
+      log.info('directories created, processing files');
+      mods.replaceTitle(options, copied, function () {
+        mods.createJSON(options, function () {
+          callback();
         });
+      });
     });
-};
-
-exports.init = function(options, callback) {
+  },
+  init : function (options, callback) {
     var start = (new Date()).getTime();
     log.info('creating module (' + options.name + ') in: ' + options.location);
     if (util.exists(options.location)) {
-        log.bail('destination already exists, you are on your own! bailing..');
+      log.bail('destination already exists, you are on your own! bailing..');
     }
 
-    createDirs(options, function() {
-        util.tree(options.location, options.root, function(tree) {
-            log.log('');
-            log.info('module created, here\'s what yogi did for you:');
-            log.log('');
-            console.log(tree);
-            log.info('yogi took ' + timethat.calc(start, new Date().getTime()) + ' to create this module');
-            callback();
-        });
+    this.createDirs(options, function () {
+      util.tree(options.location, options.root, function (tree) {
+        log.log('');
+        log.info('module created, here\'s what yogi did for you:');
+        log.log('');
+        console.log(tree);
+        log.info('yogi took ' + timethat.calc(start, new Date().getTime()) + ' to create this module');
+        callback();
+      });
     });
+  }
 };
+
+
+util.mix(exports, mods);
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -5,24 +5,19 @@ var log = require('./log'),
     path = require('path'),
     timethat = require('timethat'),
     fs = require('fs'),
-    util = require('./util'),
-    _defaultDirs = [
+    util = require('./util');
+
+
+var _defaultDirs = [
     './docs/',
     './tests/',
     './js',
     './meta',
     './css',
     './assets'
-    ],
+];
 
-mods = {
-
-  /**
-  Creates the JSON assets for the new module
-  @method createJSON
-  @param {Object} options {options.name, options.location, options.defaultDirs}
-  **/
-  createJSON : function (options, callback) {
+var createJSON = function(options, callback) {
 
     var name = options.name,
         build = {
@@ -87,10 +82,10 @@ mods = {
     log.debug('creating meta/' + name + '.json file: ' + metaFile);
     fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
     callback();
-},
+};
 
 
-replaceTitle : function(options, items, callback) {
+var replaceTitle = function(options, items, callback) {
     var tags = '[ "gallery" ]',
         title = options.name;
         author = config.get('username');
@@ -111,16 +106,15 @@ replaceTitle : function(options, items, callback) {
         }
     });
     callback();
-},
+};
 
-  createDirs : function (options, callback) {
+var createDirs = function(options, callback) {
 
     log.info('creating default directory structure');
     var stack = new util.Stack(),
         copied = [];
-        defaultDirs = options.defaultDirs || _defaultDirs;
 
-      defaultDirs.forEach(function (dir) {
+    _defaultDirs.forEach(function(dir) {
         var d = path.join(__dirname, '../defaults/', dir),
             toDir = path.join(options.location, dir);
 
@@ -144,21 +138,22 @@ replaceTitle : function(options, items, callback) {
     });
     stack.done(function() {
         log.info('directories created, processing files');
-        mods.replaceTitle(options, copied, function() {
-            mods.createJSON(options, function() {
+        replaceTitle(options, copied, function() {
+            createJSON(options, function() {
                 callback();
             });
         });
     });
-  },
-  init : function (options, callback) {
+};
+
+var init = function(options, callback) {
     var start = (new Date()).getTime();
     log.info('creating module (' + options.name + ') in: ' + options.location);
     if (util.exists(options.location)) {
         log.bail('destination already exists, you are on your own! bailing..');
     }
-
-    this.createDirs(options, function () {
+    
+    createDirs(options, function() {
         util.tree(options.location, options.root, function(tree) {
             log.log('');
             log.info('module created, here\'s what yogi did for you:');
@@ -168,10 +163,10 @@ replaceTitle : function(options, items, callback) {
             callback();
         });
     });
-  }
 };
 
-util.mix(exports, mods);
-
-
-
+module.exports = {
+    init: init,
+    createJSON: createJSON,
+    createDirs: createDirs
+}

--- a/lib/create.js
+++ b/lib/create.js
@@ -169,4 +169,4 @@ module.exports = {
     init: init,
     createJSON: createJSON,
     createDirs: createDirs
-}
+};

--- a/lib/create.js
+++ b/lib/create.js
@@ -33,7 +33,6 @@ mods = {
         builds: {}
       },
       meta = {},
-      defaultDirs = options.defaultDirs || _defaultDirs,
       codeFile = path.join(options.location, 'js', name + '.js'),
       skinBase = path.join(options.location, 'assets', name, 'skins', 'sam'),
       file = path.join(options.location, 'build.json'),

--- a/lib/create.js
+++ b/lib/create.js
@@ -5,7 +5,7 @@ var log = require('./log'),
     path = require('path'),
     timethat = require('timethat'),
     fs = require('fs'),
-    util = require('./util'),
+    util = require('./util');
     mods;
 
 
@@ -16,7 +16,7 @@ var _defaultDirs = [
     './meta',
     './css',
     './assets'
-  ];
+],
 
 mods = {
 
@@ -27,10 +27,10 @@ mods = {
   **/
   createJSON : function (options, callback) {
 
-      var name = options.name,
+    var name = options.name,
         build = {
-          name: name,
-          builds: {}
+            name: name,
+            builds: {}
         },
         meta = {},
         codeFile = path.join(options.location, 'js', name + '.js'),
@@ -40,139 +40,139 @@ mods = {
         history = path.join(options.location, 'HISTORY.md'),
         metaFile = path.join(options.location, 'meta', name + '.json');
 
-      build.builds[name] = {
-      };
+    build.builds[name] = {
+    };
+    meta[name] = {
+    };
 
-      meta[name] = {
-      };
+    switch (options.type) {
+        case 'js':
+            build.builds[name].jsfiles = [
+                'js/' + name + '.js'
+            ];
+            meta[name].requires = [ 'yui-base' ];
+            break;
+        case 'css':
+            codeFile = path.join(options.location, 'css', name + '.css'),
+            build.builds[name].cssfiles = [
+                'css/' + name + '.css'
+            ];
+            meta[name].type = 'css';
+            break;
+        case 'widget':
+            build.builds[name].jsfiles = [
+                'js/' + name + '.js'
+            ];
+            meta[name].requires = [ 'widget' ];
+            meta[name].skinnable = true;
 
-      switch (options.type) {
+            mkdirp.sync(skinBase);
+            log.info('creating skin templates');
+            fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+            fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+            break;
 
-      case 'js':
-        build.builds[name].jsfiles = [
-          'js/' + name + '.js'
-        ];
-        meta[name].requires = [ 'yui-base' ];
-        break;
-      case 'css':
-        codeFile = path.join(options.location, 'css', name + '.css');
-        build.builds[name].cssfiles = [
-          'css/' + name + '.css'
-        ];
-        meta[name].type = 'css';
-        break;
-      case 'widget':
-        build.builds[name].jsfiles = [
-          'js/' + name + '.js'
-        ];
-        meta[name].requires = [ 'widget' ];
-        meta[name].skinnable = true;
-        mkdirp.sync(skinBase);
-        log.info('creating skin templates');
-        fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-        fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-        break;
-      }
+    }
 
-      log.debug('creating README file: ' + readme);
-      fs.writeFileSync(readme, name + '\n========\n', 'utf8');
+    log.debug('creating README file: ' + readme);
+    fs.writeFileSync(readme, name + '\n========\n', 'utf8');
 
-      log.debug('creating HISTORY file: ' + history);
-      fs.writeFileSync(history, name + '\n========\n', 'utf8');
+    log.debug('creating HISTORY file: ' + history);
+    fs.writeFileSync(history, name + '\n========\n', 'utf8');
 
-      log.debug('creating code file: ' + codeFile);
-      fs.writeFileSync(codeFile, '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+    
+    log.debug('creating code file: ' + codeFile);
+    fs.writeFileSync(codeFile, '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
 
-      log.debug('creating build.json file: ' + file);
-      fs.writeFileSync(file, JSON.stringify(build, null, 4) + '\n', 'utf8');
+    log.debug('creating build.json file: ' + file);
+    fs.writeFileSync(file, JSON.stringify(build, null, 4) + '\n', 'utf8');
 
-      log.debug('creating meta/' + name + '.json file: ' + metaFile);
-      fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
-      callback();
-  },
+    log.debug('creating meta/' + name + '.json file: ' + metaFile);
+    fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
+    callback();
+},
 
-  replaceTitle : function (options, items, callback) {
-      var tags = '[ "gallery" ]',
-        title = options.name,
+
+replaceTitle : function(options, items, callback) {
+    var tags = '[ "gallery" ]',
+        title = options.name;
         author = config.get('username');
 
-      items.forEach(function (file) {
-
+    items.forEach(function(file) {
         var stat = fs.statSync(file), str;
         if (!stat.isDirectory()) {
-          log.debug('updating title in ' + file);
-          str = fs.readFileSync(file, 'utf8');
-          str = str.replace(/\{\{title\}\}/gi, title);
-          str = str.replace(/\{\{name\}\}/gi, title);
-          str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
-          str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
-          str = str.replace(/\{\{tags\}\}/gi, tags);
-          str = str.replace(/\{\{author\}\}/gi, author);
-          str = str.replace(/\{\{code\}\}/gi, '//Module example code');
-          fs.writeFileSync(file, str, 'utf8');
+            log.debug('updating title in ' + file);
+            str = fs.readFileSync(file, 'utf8');
+            str = str.replace(/\{\{title\}\}/gi, title);
+            str = str.replace(/\{\{name\}\}/gi, title);
+            str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
+            str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
+            str = str.replace(/\{\{tags\}\}/gi, tags);
+            str = str.replace(/\{\{author\}\}/gi, author);
+            str = str.replace(/\{\{code\}\}/gi, '//Module example code');
+            fs.writeFileSync(file, str, 'utf8');
         }
-      });
+    });
+    callback();
+},
 
-      callback();
-  },
   createDirs : function (options, callback) {
 
     log.info('creating default directory structure');
     var stack = new util.Stack(),
-      copied = [],
-      defaultDirs = options.defaultDirs || _defaultDirs;
+        copied = [];
+        defaultDirs = options.defaultDirs || _defaultDirs;
 
-    defaultDirs.forEach(function (dir) {
-      var d = path.join(__dirname, '../defaults/', dir),
-        toDir = path.join(options.location, dir);
+      defaultDirs.forEach(function (dir) {
+        var d = path.join(__dirname, '../defaults/', dir),
+            toDir = path.join(options.location, dir);
 
-      if (util.exists(toDir)) {
-        log.info('did not create default directory, it exists: ' + toDir);
-        return;
-      }
-      if (util.exists(d)) {
-        log.debug('copying dir from ' + d);
-        log.debug('to ' + toDir);
-        mkdirp(toDir, stack.add(function () {
-          cpr(d, toDir, stack.add(function (err, status) {
-            copied = [].concat(copied, status);
-          }));
-        }));
-      } else {
-        log.debug('making ' + toDir);
-        mkdirp(toDir, stack.add(function () {
-        }));
-      }
+        if (util.exists(toDir)) {
+            log.info('did not create default directory, it exists: ' + toDir);
+            return;
+        }
+        if (util.exists(d)) {
+            log.debug('copying dir from ' + d);
+            log.debug('to ' + toDir);
+            mkdirp(toDir, stack.add(function() {
+                cpr(d, toDir, stack.add(function(err, status) {
+                    copied = [].concat(copied, status);
+                }));
+            }));
+        } else {
+            log.debug('making ' + toDir);
+            mkdirp(toDir, stack.add(function() {
+            }));
+        }
     });
-    stack.done(function () {
-      log.info('directories created, processing files');
-      mods.replaceTitle(options, copied, function () {
-        mods.createJSON(options, function () {
-          callback();
+    stack.done(function() {
+        log.info('directories created, processing files');
+        mods.replaceTitle(options, copied, function() {
+            mods.createJSON(options, function() {
+                callback();
+            });
         });
-      });
     });
   },
   init : function (options, callback) {
     var start = (new Date()).getTime();
     log.info('creating module (' + options.name + ') in: ' + options.location);
     if (util.exists(options.location)) {
-      log.bail('destination already exists, you are on your own! bailing..');
+        log.bail('destination already exists, you are on your own! bailing..');
     }
 
     this.createDirs(options, function () {
-      util.tree(options.location, options.root, function (tree) {
-        log.log('');
-        log.info('module created, here\'s what yogi did for you:');
-        log.log('');
-        console.log(tree);
-        log.info('yogi took ' + timethat.calc(start, new Date().getTime()) + ' to create this module');
-        callback();
-      });
+        util.tree(options.location, options.root, function(tree) {
+            log.log('');
+            log.info('module created, here\'s what yogi did for you:');
+            log.log('');
+            console.log(tree);
+            log.info('yogi took ' + timethat.calc(start, new Date().getTime()) + ' to create this module');
+            callback();
+        });
     });
   }
 };
 
 
 util.mix(exports, mods);
-

--- a/lib/create.js
+++ b/lib/create.js
@@ -1,12 +1,12 @@
 var log = require('./log'),
-  cpr = require('cpr').cpr,
-  mkdirp = require('mkdirp'),
-  config = require('./config'),
-  path = require('path'),
-  timethat = require('timethat'),
-  fs = require('fs'),
-  util = require('./util'),
-  mods;
+    cpr = require('cpr').cpr,
+    mkdirp = require('mkdirp'),
+    config = require('./config'),
+    path = require('path'),
+    timethat = require('timethat'),
+    fs = require('fs'),
+    util = require('./util'),
+    mods;
 
 
 var _defaultDirs = [
@@ -27,93 +27,93 @@ mods = {
   **/
   createJSON : function (options, callback) {
 
-    var name = options.name,
-      build = {
-        name: name,
-        builds: {}
-      },
-      meta = {},
-      codeFile = path.join(options.location, 'js', name + '.js'),
-      skinBase = path.join(options.location, 'assets', name, 'skins', 'sam'),
-      file = path.join(options.location, 'build.json'),
-      readme = path.join(options.location, 'README.md'),
-      history = path.join(options.location, 'HISTORY.md'),
-      metaFile = path.join(options.location, 'meta', name + '.json');
+      var name = options.name,
+        build = {
+          name: name,
+          builds: {}
+        },
+        meta = {},
+        codeFile = path.join(options.location, 'js', name + '.js'),
+        skinBase = path.join(options.location, 'assets', name, 'skins', 'sam'),
+        file = path.join(options.location, 'build.json'),
+        readme = path.join(options.location, 'README.md'),
+        history = path.join(options.location, 'HISTORY.md'),
+        metaFile = path.join(options.location, 'meta', name + '.json');
 
-    build.builds[name] = {
-    };
+      build.builds[name] = {
+      };
 
-    meta[name] = {
-    };
+      meta[name] = {
+      };
 
-    switch (options.type) {
+      switch (options.type) {
 
-    case 'js':
-      build.builds[name].jsfiles = [
-        'js/' + name + '.js'
-      ];
-      meta[name].requires = [ 'yui-base' ];
-      break;
-    case 'css':
-      codeFile = path.join(options.location, 'css', name + '.css');
-      build.builds[name].cssfiles = [
-        'css/' + name + '.css'
-      ];
-      meta[name].type = 'css';
-      break;
-    case 'widget':
-      build.builds[name].jsfiles = [
-        'js/' + name + '.js'
-      ];
-      meta[name].requires = [ 'widget' ];
-      meta[name].skinnable = true;
-      mkdirp.sync(skinBase);
-      log.info('creating skin templates');
-      fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-      fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
-      break;
-    }
+      case 'js':
+        build.builds[name].jsfiles = [
+          'js/' + name + '.js'
+        ];
+        meta[name].requires = [ 'yui-base' ];
+        break;
+      case 'css':
+        codeFile = path.join(options.location, 'css', name + '.css');
+        build.builds[name].cssfiles = [
+          'css/' + name + '.css'
+        ];
+        meta[name].type = 'css';
+        break;
+      case 'widget':
+        build.builds[name].jsfiles = [
+          'js/' + name + '.js'
+        ];
+        meta[name].requires = [ 'widget' ];
+        meta[name].skinnable = true;
+        mkdirp.sync(skinBase);
+        log.info('creating skin templates');
+        fs.writeFileSync(path.join(skinBase, name + '-skin.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+        fs.writeFileSync(path.join(skinBase, '../../', name + '-core.css'), '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+        break;
+      }
 
-    log.debug('creating README file: ' + readme);
-    fs.writeFileSync(readme, name + '\n========\n', 'utf8');
+      log.debug('creating README file: ' + readme);
+      fs.writeFileSync(readme, name + '\n========\n', 'utf8');
 
-    log.debug('creating HISTORY file: ' + history);
-    fs.writeFileSync(history, name + '\n========\n', 'utf8');
+      log.debug('creating HISTORY file: ' + history);
+      fs.writeFileSync(history, name + '\n========\n', 'utf8');
 
-    log.debug('creating code file: ' + codeFile);
-    fs.writeFileSync(codeFile, '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
+      log.debug('creating code file: ' + codeFile);
+      fs.writeFileSync(codeFile, '\n/**\n Your Code Goes Here\n*/\n', 'utf8');
 
-    log.debug('creating build.json file: ' + file);
-    fs.writeFileSync(file, JSON.stringify(build, null, 4) + '\n', 'utf8');
+      log.debug('creating build.json file: ' + file);
+      fs.writeFileSync(file, JSON.stringify(build, null, 4) + '\n', 'utf8');
 
-    log.debug('creating meta/' + name + '.json file: ' + metaFile);
-    fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
-    callback();
+      log.debug('creating meta/' + name + '.json file: ' + metaFile);
+      fs.writeFileSync(metaFile, JSON.stringify(meta, null, 4) + '\n', 'utf8');
+      callback();
   },
 
   replaceTitle : function (options, items, callback) {
-    var tags = '[ "gallery" ]',
-      title = options.name,
-      author = config.get('username');
+      var tags = '[ "gallery" ]',
+        title = options.name,
+        author = config.get('username');
 
-    items.forEach(function (file) {
+      items.forEach(function (file) {
 
-      var stat = fs.statSync(file), str;
-      if (!stat.isDirectory()) {
-        log.debug('updating title in ' + file);
-        str = fs.readFileSync(file, 'utf8');
-        str = str.replace(/\{\{title\}\}/gi, title);
-        str = str.replace(/\{\{name\}\}/gi, title);
-        str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
-        str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
-        str = str.replace(/\{\{tags\}\}/gi, tags);
-        str = str.replace(/\{\{author\}\}/gi, author);
-        str = str.replace(/\{\{code\}\}/gi, '//Module example code');
-        fs.writeFileSync(file, str, 'utf8');
-      }
-    });
+        var stat = fs.statSync(file), str;
+        if (!stat.isDirectory()) {
+          log.debug('updating title in ' + file);
+          str = fs.readFileSync(file, 'utf8');
+          str = str.replace(/\{\{title\}\}/gi, title);
+          str = str.replace(/\{\{name\}\}/gi, title);
+          str = str.replace(/\{\{summary\}\}/gi, '*Summary Goes Here*');
+          str = str.replace(/\{\{description\}\}/gi, '*Module Description Goes Here*');
+          str = str.replace(/\{\{tags\}\}/gi, tags);
+          str = str.replace(/\{\{author\}\}/gi, author);
+          str = str.replace(/\{\{code\}\}/gi, '//Module example code');
+          fs.writeFileSync(file, str, 'utf8');
+        }
+      });
 
-    callback();
+      callback();
   },
   createDirs : function (options, callback) {
 

--- a/lib/create.js
+++ b/lib/create.js
@@ -5,18 +5,15 @@ var log = require('./log'),
     path = require('path'),
     timethat = require('timethat'),
     fs = require('fs'),
-    util = require('./util');
-    mods;
-
-
-var _defaultDirs = [
+    util = require('./util'),
+    _defaultDirs = [
     './docs/',
     './tests/',
     './js',
     './meta',
     './css',
     './assets'
-],
+    ],
 
 mods = {
 


### PR DESCRIPTION
I am using Yogi sub commands for adding some features that I need for example, I need to generate an app skeleton from some configuration file. I have looked at create.js in yogi/lib/, in this file, I have found some functions like
createJSON(), and createDirs() which I would like to use in my custom sub command. The problem is that I can not access to these functions from my custom sub command.

I make YogiCreate = require(path.join(YOGI_PATH, 'lib/create')), but YogiCreate only contain the init() function. That is because create.js only export the init() function.

We could fix that in create.js, if we could export the createJSON() and createDirs() function.

I think that could be good, for adding more Yogi extensibility and reusability.

Best Regards Dariel
