### PR TITLE
Launching tests from a sub-project that doesn't have a gitroot

### DIFF
--- a/lib/cmds/test.js
+++ b/lib/cmds/test.js
@@ -436,11 +436,11 @@ mods = {
             }
             if (canBatch) {
                 find(CWD, 'package.json', function(err, file) {
-                   if (file) {
-                      base = path.join(path.dirname(file), 'src');
-                   } else {
-                      base = path.join(git.findRoot(), '../src');
-                   }
+                    if (file) {
+                        base = path.join(path.dirname(file), 'src');
+                    } else {
+                        base = path.join(git.findRoot(), '../src');
+                    }
                 });
                 if (!this.modules) {
                     this.modules = [];

--- a/lib/cmds/test.js
+++ b/lib/cmds/test.js
@@ -5,6 +5,8 @@ http://yuilibrary.com/license/
 */
 var log = require('../log'),
     util = require('../util'),
+    find = util.find,
+    CWD = process.cwd(),
     git = require('../git'),
     path = require('path'),
     portfinder = require('portfinder'),
@@ -433,7 +435,13 @@ mods = {
                 canBatch = true;
             }
             if (canBatch) {
-                base = path.join(git.findRoot(), '../src');
+                find(CWD, 'package.json', function(err, file) {
+                   if (file) {
+                      base = path.join(path.dirname(file), 'src');
+                   } else {
+                      base = path.join(git.findRoot(), '../src');
+                   }
+                });
                 if (!this.modules) {
                     this.modules = [];
                     batch = fs.readdirSync(base);


### PR DESCRIPTION
**Hello!**

I was trying to launch my test suites of a yui project with yogi lately, and had no tests launch. Therefore I took a look inside the test resolver inside yogi. I found out that the current code searches for tests in the `<closest_gitroot>/src/` directory. 

The problem here is that if you have sub-projects inside on git repo, it will search for test at the git root, but not at the package root. Therefor this PR searches for the closest `package.json` and resolves the base path from there. If no package.json is found, it folds back to the current code (the gitroot).

Let me know if this is you'd like to integrate into yogi.
