### PR TITLE
Long running tests process because of search inside all node_modules installed

### DIFF
--- a/lib/cmds/serve.js
+++ b/lib/cmds/serve.js
@@ -86,7 +86,7 @@ mods = {
         finder.on('path', function(file, stat) {
             if (stat.isFile()) {
                 var name = path.basename(file);
-                if (name === 'build.json') {
+                if (name === 'build.json' && !/node_modules\//.test(path.dirname(file))) {
                     mods.push(path.basename(path.dirname(file)));
                 }
             }


### PR DESCRIPTION
I get a long running process searching for all modules that have a `build.json` file. 
This PR checks the path of the modules parsed to not include the node_modules ones.

---

As in my other pr #96, all tests pass correctly

``` bash
npm test -f
```

(in order to pass the linting errors) makes the tests pass:

```
✓ OK » 84 honored (0.015s) 
```
