### PR TITLE
Replace the failing findit dependency with the API-compatible node-walkdir

### DIFF
--- a/lib/cmds/lint.js
+++ b/lib/cmds/lint.js
@@ -7,7 +7,7 @@ var util = require('../util'),
     log = require('../log'),
     path = require('path'),
     fs = require('fs'),
-    findit = require('findit'),
+    walkdir = require('walkdir'),
     linter = require('jshint').JSHINT,
     lint = require('yui-lint'),
 mods = {
@@ -27,7 +27,7 @@ mods = {
     },
     lint: function() {
         log.info('running lint on source files');
-        var finder = findit(path.join(this.dir, 'js')),
+        var finder = walkdir(path.join(this.dir, 'js')),
             metaFiles, lintFiles = [], docFiles = [],
             metaFilesDir = path.join(this.dir, 'meta'),
             dir = this.dir,

--- a/lib/cmds/serve.js
+++ b/lib/cmds/serve.js
@@ -23,7 +23,7 @@ var util = require('../util'),
     osenv = require('osenv'),
     istanbulBase = path.join(osenv.tmpdir(), 'yogi-istanbul'),
     portfinder = require('portfinder'),
-    findit = require('findit'),
+    walkdir = require('walkdir'),
     ansispan = require('ansispan'),
     mods;
 
@@ -79,7 +79,7 @@ mods = {
         }
     },
     scan: function(callback) {
-        var finder = findit.find(process.cwd()),
+        var finder = walkdir.find(process.cwd()),
             mods = [],
             self = this;
 

--- a/lib/cmds/test.js
+++ b/lib/cmds/test.js
@@ -10,7 +10,7 @@ var log = require('../log'),
     portfinder = require('portfinder'),
     fs = require('fs'),
     server = require('./serve'),
-    findit = require('findit'),
+    walkdir = require('walkdir'),
     fork = require('child_process').fork,
     spawn = require('win-spawn'), //comma
 mods = {
@@ -136,7 +136,7 @@ mods = {
     },
     scan: function(callback) {
         log.debug('scanning for gallery modules..');
-        var finder = findit.find(process.cwd()),
+        var finder = walkdir.find(process.cwd()),
             mods = [],
             self = this;
 

--- a/lib/util.js
+++ b/lib/util.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
     osenv = require('osenv'),
     log = require('./log'),
     treeify = require('treeify'),
-    findit = require('findit'),
+    walkdir = require('walkdir'),
     exists = fs.existsSync || path.existsSync,
     readline = require('readline'),
     editor = require('editor'),
@@ -286,7 +286,7 @@ mods.getTests = function(dir, coverage) {
 };
 
 mods.tree = function(start, root, callback) {
-    var finder = findit.find(start),
+    var finder = walkdir.find(start),
         tree = {};
 
     finder.on('path', function(file, stat) {

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
         "portfinder": "~0.2.1",
         "echoecho": "~0.1.4",
         "istanbul": "0.1.37",
-        "findit": "~0.1.2",
+        "walkdir": "~0.0.7",
         "treeify": "~0.2.0",
         "yeti": "~0.2.23",
         "editor": "~0.0.4",


### PR DESCRIPTION
The reasons are the following:
- The 0.1.2 version of findit failed with the following error message at my and some of my co-workers computers till recently:

`/helptool/node_modules/findit/node_modules/seq/node_modules/hashish/index.js:146
self[key] = propskey;
RangeError: Maximum call stack size exceeded`

Trying to hack with `node --stack-size=32000` didn't work great.
- When I removed yogi and tried to reinstall now it failed due to this findit dependency version not being available anymore

Even if this pull request is not accepted, something has to be done because yogi is broken.

See https://github.com/substack/node-findit/issues/24
