### PR TITLE
Add the option of exporting code coverage to the yogi test help message

### DIFF
--- a/lib/cmds/test.js
+++ b/lib/cmds/test.js
@@ -620,6 +620,7 @@ mods = {
             'from ./src to test all',
             '--port <number> to change the testing port',
             '--coverage to generate a coverage report',
+            '--coverdir <Path> generate a full lcov coverage report here',
             '--cli to run only cli tests',
             '--filter (min|raw|debug) pass filter to test files',
             '--functional Also run the Selleck functional tests',


### PR DESCRIPTION
It's a hidden feature right now, it'd be nice to know it exists without having to look at the source code.
