### PR TITLE
no SSL for you!

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -25,11 +25,8 @@ config.register('token', 'token for auth with yuilibrary.com', true);
 
 mod = {
     strictSSL: function() {
-        var devel = config.get('devel');
-        if (devel) {
-            log.warn('USING API WITHOUT STRICT SSL CHECKING');
-        }
-        return !devel;
+        // yuilibrary.com no longer does SSL
+        return false;
     },
     host: function() {
         return 'http://' + config.get('apiHost') + '/api/v1';


### PR DESCRIPTION
Yesterday we turned off SSL for yuilibrary.com. This PR is a wild guess at getting yogi to work with this change.
